### PR TITLE
Disable fail-fast in Ruby CI workflow matrix

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -13,6 +13,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         ruby-version: ['3.1', '3.2', '3.3', '3.4', 'jruby-9.4', 'jruby-10.0']
 


### PR DESCRIPTION
Disable fail-fast in the workflow so if it fails on one Ruby version, it will continue running others. That will make it easier to figure out if a failure is version specific or not.