### PR TITLE
Disable fail-fast in Ruby CI workflow

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -13,6 +13,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         ruby-version: ['3.1', '3.2', '3.3', '3.4', '4.0', 'head', 'jruby-9.4', 'jruby-10.0']
 


### PR DESCRIPTION
Disable fail-fast strategy for Ruby tests so if one version fails we keep running.

This is a replacement for #15 which I accidentally closed by deleting my fork too quickly :laughing: 